### PR TITLE
FIX: Fix options being incorrect when multiple options are provided (incorrect pointer math).

### DIFF
--- a/cs/hello_ffi/LanceDbClientTests/Connections.cs
+++ b/cs/hello_ffi/LanceDbClientTests/Connections.cs
@@ -14,6 +14,47 @@ public partial class Tests
         using var cnn = new Connection(uri);
         cnn.DropDatabase();
     }
+
+    /*[Test]
+    public void TestLocalMinio()
+    {
+        // Connect with options
+        var uri = new Uri("s3://lance");
+        var options = new Dictionary<String, String>()
+        {
+            { "AWS_ACCESS_KEY_ID", "MyKey" },
+            { "AWS_SECRET_ACCESS_KEY", "MySecretKey" },
+            { "AWS_REGION", "can-1" },
+            { "AWS_ENDPOINT", "http://localhost:9000" },
+            { "AWS_DEFAULT_REGION", "true" },
+            { "allow_http", "true" },
+        };
+        // Connect
+        using (var cnn = new Connection(uri, options))
+        {
+            Assert.That(cnn.IsOpen, Is.True);
+            Assert.That(cnn.Uri, Is.EqualTo(uri));
+            
+            // There should be no tables
+            Assert.That(cnn.TableNames(), Is.Empty);
+            
+            // Create a table and make sure it's present
+            var table = cnn.CreateTable("table1", Helpers.GetSchema());
+            Assert.Multiple(() =>
+            {
+                Assert.That(table, Is.Not.Null);
+                Assert.That(cnn.TableNames(), Does.Contain("table1"));
+            });
+            
+            // Remove the table and make sure it's gone
+            cnn.DropTable("table1");
+            Assert.That(cnn.TableNames(), Is.Empty);
+            
+            // Clean up
+            cnn.DropDatabase();
+            Assert.That(cnn.IsOpen, Is.False);
+        }
+    }*/
     
     [Test]
     public void TestNewDatabaseCreationAndDropping()

--- a/rust/lance_sync_client/src/connection_handler.rs
+++ b/rust/lance_sync_client/src/connection_handler.rs
@@ -44,6 +44,8 @@ impl ConnectionActor {
                         storage_options,
                     } => {
                         let mut connection = connect(&uri);
+                        //println!("Connecting to {uri}");
+                        //println!("Storage options: {storage_options:?}");
                         if let Some(storage_options) = storage_options {
                             for (key, value) in storage_options {
                                 connection = connection.storage_option(key, value);

--- a/rust/lance_sync_client/src/exports.rs
+++ b/rust/lance_sync_client/src/exports.rs
@@ -33,13 +33,14 @@ pub extern "C" fn connect(uri: *const c_char, options_length: u64, options: *con
     } else {
         let mut storage_options = Vec::new();
         for i in 0..options_length/2 {
+            let base = (i * 2) as isize;
             let key = unsafe {
-                std::ffi::CStr::from_ptr(*options.offset(i as isize))
+                std::ffi::CStr::from_ptr(*options.offset(base))
                     .to_string_lossy()
                     .to_string()
             };
             let value = unsafe {
-                std::ffi::CStr::from_ptr(*options.offset((i + 1) as isize))
+                std::ffi::CStr::from_ptr(*options.offset(base+1))
                     .to_string_lossy()
                     .to_string()
             };


### PR DESCRIPTION
* Fixes the pointer math.
* Adds a commented-out unit test demonstrating a working Minio connection.

```cs
[Test]
    public void TestLocalMinio()
    {
        // Connect with options
        var uri = new Uri("s3://lance");
        var options = new Dictionary<String, String>()
        {
            { "AWS_ACCESS_KEY_ID", "MyKey" },
            { "AWS_SECRET_ACCESS_KEY", "MySecretKey" },
            { "AWS_REGION", "can-1" },
            { "AWS_ENDPOINT", "http://localhost:9000" },
            { "AWS_DEFAULT_REGION", "true" },
            { "allow_http", "true" },
        };
        // Connect
        using (var cnn = new Connection(uri, options))
        {
            Assert.That(cnn.IsOpen, Is.True);
            Assert.That(cnn.Uri, Is.EqualTo(uri));
            
            // There should be no tables
            Assert.That(cnn.TableNames(), Is.Empty);
            
            // Create a table and make sure it's present
            var table = cnn.CreateTable("table1", Helpers.GetSchema());
            Assert.Multiple(() =>
            {
                Assert.That(table, Is.Not.Null);
                Assert.That(cnn.TableNames(), Does.Contain("table1"));
            });
            
            // Remove the table and make sure it's gone
            cnn.DropTable("table1");
            Assert.That(cnn.TableNames(), Is.Empty);
            
            // Clean up
            cnn.DropDatabase();
            Assert.That(cnn.IsOpen, Is.False);
        }
    }
```