### PR TITLE
Updates LanceDb to 0.17.0.

### DIFF
--- a/cs/hello_ffi/LanceDbClient/IndexType.cs
+++ b/cs/hello_ffi/LanceDbClient/IndexType.cs
@@ -8,6 +8,7 @@
         Fts = 3,
         HnswPq = 4,
         HnswSq = 5,
-        IvfPq = 6
+        IvfPq = 6,
+        IvfFlat = 7
     }
 }

--- a/cs/hello_ffi/LanceDbClientTests/Tables.cs
+++ b/cs/hello_ffi/LanceDbClientTests/Tables.cs
@@ -625,7 +625,7 @@ public partial class Tests
     }
     
     [Test]
-    public void CreateDefaultScalarIndexFailsOnEmpty()
+    public void CreateDefaultScalarIndexIsOkOnEmpty()
     {
         var uri = new Uri("file:///tmp/test_table_empty_try_index");
         try
@@ -634,7 +634,7 @@ public partial class Tests
             {
                 Assert.That(cnn.IsOpen, Is.True);
                 var table = cnn.CreateTable("table1", Helpers.GetSchema());
-                Assert.Throws<Exception>(() => table.CreateScalarIndex("id"));
+                // Note: the behavior changed, this no longer throws on the LanceDb side.
             }
         }
         finally
@@ -646,7 +646,7 @@ public partial class Tests
     }
     
     [Test]
-    public async Task CreateDefaultScalarIndexFailsOnEmptyAsync()
+    public async Task CreateDefaultScalarIndexFIsOkOnEmptyAsync()
     {
         var uri = new Uri("file:///tmp/test_table_empty_try_index_async");
         try
@@ -655,7 +655,8 @@ public partial class Tests
             {
                 Assert.That(cnn.IsOpen, Is.True);
                 var table = await cnn.CreateTableAsync("table1", Helpers.GetSchema());
-                Assert.ThrowsAsync<Exception>(async () => await table.CreateScalarIndexAsync("id"));
+                //Assert.ThrowsAsync<Exception>(async () => await table.CreateScalarIndexAsync("id"));
+                // Note: the behavior changed, this no longer throws on the LanceDb side.
             }
         }
         finally

--- a/cs/hello_ffi/hello_ffi.sln.DotSettings.user
+++ b/cs/hello_ffi/hello_ffi.sln.DotSettings.user
@@ -33,22 +33,22 @@
 	<s:String x:Key="/Default/Environment/AssemblyExplorer/XmlDocument/@EntryValue">&lt;AssemblyExplorer&gt;
   &lt;Assembly Path="/home/herbert/.nuget/packages/apache.arrow/17.0.0/lib/net8.0/Apache.Arrow.dll" /&gt;
 &lt;/AssemblyExplorer&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=0e8a6b1d_002Dbcfa_002D4e9f_002D9c6c_002Debfce37508a8/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="SimpleMergeInsert" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;Project Location="\home\herbert\Rust\lancedb_csharp\cs\hello_ffi\LanceDbClientTests" Presentation="&amp;lt;LanceDbClientTests&amp;gt;" /&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=0e8a6b1d_002Dbcfa_002D4e9f_002D9c6c_002Debfce37508a8/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="SimpleMergeInsert" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;Project Location="/home/herbert/Rust/lancedb_csharp/cs/hello_ffi/LanceDbClientTests" Presentation="&amp;lt;LanceDbClientTests&amp;gt;" /&gt;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=324bbfbc_002D55e7_002D448b_002Da7d5_002Db439c39cbf4c/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="FullTextSearchIndexStats" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;Project Location="\home\herbert\Rust\lancedb_csharp\cs\hello_ffi\LanceDbClientTests" Presentation="&amp;lt;LanceDbClientTests&amp;gt;" /&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=324bbfbc_002D55e7_002D448b_002Da7d5_002Db439c39cbf4c/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="FullTextSearchIndexStats" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;Project Location="\home\herbert\Rust\lancedb_csharp\cs\hello_ffi\LanceDbClientTests" Presentation="&amp;lt;LanceDbClientTests&amp;gt;" /&gt;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=9809afec_002Df963_002D4f2f_002Dbd6a_002Deced8b9dc472/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="TestOptimizeRowsAsync" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;NUnit3x::8EBD6D2C-11FC-44D9-9DB4-ED9095674B7E::net8.0::LanceDbClientTests.Tests.TestOptimizeRowsAsync&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=9809afec_002Df963_002D4f2f_002Dbd6a_002Deced8b9dc472/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="TestOptimizeRowsAsync" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;TestAncestor&gt;
+    &lt;TestId&gt;NUnit3x::8EBD6D2C-11FC-44D9-9DB4-ED9095674B7E::net8.0::LanceDbClientTests.Tests.TestOptimizeRowsAsync&lt;/TestId&gt;
+  &lt;/TestAncestor&gt;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bd32ed6b_002Deb14_002D4aa0_002D910c_002D8935f1fc3840/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Tests" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;NUnit3x::8EBD6D2C-11FC-44D9-9DB4-ED9095674B7E::net8.0::LanceDbClientTests.Tests&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bd32ed6b_002Deb14_002D4aa0_002D910c_002D8935f1fc3840/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Tests" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;TestAncestor&gt;
+    &lt;TestId&gt;NUnit3x::8EBD6D2C-11FC-44D9-9DB4-ED9095674B7E::net8.0::LanceDbClientTests.Tests&lt;/TestId&gt;
+  &lt;/TestAncestor&gt;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bfdd8fd3_002D3b6b_002D442b_002D9fce_002D3f64c38aa695/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="RerankFieldOrder" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;Project Location="\home\herbert\Rust\lancedb_csharp\cs\hello_ffi\LanceDbClientTests" Presentation="&amp;lt;LanceDbClientTests&amp;gt;" /&gt;&#xD;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bfdd8fd3_002D3b6b_002D442b_002D9fce_002D3f64c38aa695/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="RerankFieldOrder" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;Project Location="\home\herbert\Rust\lancedb_csharp\cs\hello_ffi\LanceDbClientTests" Presentation="&amp;lt;LanceDbClientTests&amp;gt;" /&gt;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.dependencies]
-lancedb = { version = "=0.14.0" } # Pinned to a released version to avoid breaking changes.
+lancedb = { version = "=0.17.0" } # Pinned to a released version to avoid breaking changes.
 tokio = { version = "1", features = ["full"] }
 futures = "0.3.31"
 anyhow = "1"
@@ -25,7 +25,6 @@ anyhow = "1"
 arrow-array = "53.2.0"
 arrow-schema = "53.2.0"
 arrow-ipc = "53.2.0"
-once_cell = "1.20.2"
 half = { "version" = "=2.4.1", default-features = false, features = [
     "num-traits",
 ] }

--- a/rust/batch_testing/src/main.rs
+++ b/rust/batch_testing/src/main.rs
@@ -16,8 +16,18 @@ const BATCH_LENGTH: u32 = 2;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Connect to the database
-    let uri = "/tmp/test-batching";
-    let db = connect(uri).execute().await?;
+    //let uri = "/tmp/test-batching";
+    //let db = connect(uri).execute().await?;
+
+    let uri = "s3://lance";
+    let db = connect(uri)
+        .storage_option("AWS_ACCESS_KEY_ID", "DQ0BYWgxZabV1dLHI3lV")
+        .storage_option("AWS_SECRET_ACCESS_KEY", "eVohlSvZtuKKw25T3XdTPCtR4aFhbnazMzsmE16g")
+        .storage_option("AWS_REGION", "can-1")
+        .storage_option("AWS_ENDPOINT", "http://localhost:9000")
+        .storage_option("AWS_DEFAULT_REGION", "true")
+        .storage_option("allow_http", "true")
+        .execute().await?;
 
     // Create some initial data
     let initial_data = create_some_records()?;
@@ -61,7 +71,7 @@ async fn main() -> Result<()> {
     }
 
     // Clean up
-    db.drop_db().await?;
+    db.drop_all_tables().await?;
 
     // Return success if nothing goes wrong
     Ok(())

--- a/rust/lance_sync_client/Cargo.toml
+++ b/rust/lance_sync_client/Cargo.toml
@@ -15,5 +15,5 @@ arrow-schema = { workspace = true }
 arrow-ipc = { workspace = true }
 futures = { workspace = true }
 half = { workspace = true }
-strum = "0.26.3"
+strum = {  version = "0.27.1", features = ["derive"] }
 chrono = "0.4.39"

--- a/rust/lance_sync_client/src/event_loop/command.rs
+++ b/rust/lance_sync_client/src/event_loop/command.rs
@@ -212,6 +212,7 @@ pub(crate) enum IndexType {
     HnswPq = 4,
     HnswSq = 5,
     IvfPq = 6,
+    IvfFlat = 7,
 }
 
 /// Scalar Index types that can be created.
@@ -233,6 +234,7 @@ impl From<lancedb::index::IndexType> for IndexType {
             lancedb::index::IndexType::IvfPq => Self::IvfPq,
             lancedb::index::IndexType::IvfHnswPq => Self::HnswPq,
             lancedb::index::IndexType::IvfHnswSq => Self::HnswSq,
+            lancedb::index::IndexType::IvfFlat => Self::IvfFlat,
         }
     }
 }

--- a/rust/lance_sync_client/src/event_loop/connection.rs
+++ b/rust/lance_sync_client/src/event_loop/connection.rs
@@ -77,7 +77,7 @@ pub(crate) async fn do_drop_database(
     completion_sender: CompletionSender,
 ) {
     if let Some(cnn) = get_connection(connections.clone(), connection_handle).await {
-        match cnn.drop_db().await {
+        match cnn.drop_all_tables().await {
             Ok(_) => {
                 report_result(Ok(0), reply_sender, Some(completion_sender)).await;
             }


### PR DESCRIPTION
* Adds the `IvfFlat` index type.
* Replaces "drop_db" with "drop_all_tables" due to deprecation.
* Replaces the unit tests designed to fail on creating a scalar index on an empty table, because that is no longer an error upstream.
* Remove unused 'once_cell' dependency.